### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "0.10"
+before_script:
+  - npm install
+script:
+  - ./grunt build --test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 before_script:
   - npm install
 script:
-  - ./grunt build --test
+  - ./grunt karma:continuous-integration

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -134,22 +134,6 @@ module.exports = function(grunt) {
     ]);
   });
 
-  // continuous-integration   - Run single run of unit tests in headless browsers, compile files to build directory
-  //    [--no-install-deps]   - Skip dependency installation.
-  grunt.registerTask('build', 'Build, optionally run tests', function(){
-    if(! grunt.option('no-install-deps')){
-      grunt.task.run([
-        'npm-install',
-      ]);
-    }
-
-    grunt.task.run([
-      'karma:continuous-integration',
-      'clean:build',
-      'coffee:build',
-    ]);
-  });
-
   // build            - Compile files to build directory, watch files for changes, optionally run tests concurrently
   //    [--test]              - Run unit tests concurrently
   //    [--no-install-deps]   - Skip dependency installation.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,7 @@ module.exports = function(grunt) {
     // Karma - test runner
     // karma:concurrent   - Run test in the background
     // karma:single       - Run tests once
+    // karma:continuous-integration  - Run tests only in headless browsers, for use during continuous integration
     karma: {
       options: {
         configFile: 'karma.conf.js'
@@ -70,6 +71,11 @@ module.exports = function(grunt) {
       // Run tests once
       single: {
         singleRun: true
+      },
+      // Run only in headless browsers
+      'continuous-integration': {
+        singleRun: true,
+        browsers: ['PhantomJS'],
       }
     },
 
@@ -125,6 +131,22 @@ module.exports = function(grunt) {
       'clean:build',
       'coffee:build',
       'karma:single'
+    ]);
+  });
+
+  // continuous-integration   - Run single run of unit tests in headless browsers, compile files to build directory
+  //    [--no-install-deps]   - Skip dependency installation.
+  grunt.registerTask('build', 'Build, optionally run tests', function(){
+    if(! grunt.option('no-install-deps')){
+      grunt.task.run([
+        'npm-install',
+      ]);
+    }
+
+    grunt.task.run([
+      'karma:continuous-integration',
+      'clean:build',
+      'coffee:build',
     ]);
   });
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Coffeescript Lib Skeleton
 
+[![Build Status](https://travis-ci.org/sarahquigley/coffeescript-lib-skeleton.svg?branch=add-travis-ci)](https://travis-ci.org/sarahquigley/coffeescript-lib-skeleton)
+
 A skeleton for creating Javascript libraries in Coffeescript.
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Coffeescript Lib Skeleton
 
 [![Build Status](https://travis-ci.org/sarahquigley/coffeescript-lib-skeleton.svg?branch=add-travis-ci)](https://travis-ci.org/sarahquigley/coffeescript-lib-skeleton)
+[![Dependency Status](https://gemnasium.com/sarahquigley/coffeescript-lib-skeleton.svg)](https://gemnasium.com/sarahquigley/coffeescript-lib-skeleton)
 [![devDependency Status](https://david-dm.org/sarahquigley/coffeescript-lib-skeleton/dev-status.svg)](https://david-dm.org/sarahquigley/coffeescript-lib-skeleton#info=devDependencies)
 
 A skeleton for creating Javascript libraries in Coffeescript.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Coffeescript Lib Skeleton
 
 [![Build Status](https://travis-ci.org/sarahquigley/coffeescript-lib-skeleton.svg?branch=add-travis-ci)](https://travis-ci.org/sarahquigley/coffeescript-lib-skeleton)
+[![devDependency Status](https://david-dm.org/sarahquigley/coffeescript-lib-skeleton/dev-status.svg)](https://david-dm.org/sarahquigley/coffeescript-lib-skeleton#info=devDependencies)
 
 A skeleton for creating Javascript libraries in Coffeescript.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Coffeescript Lib Skeleton
 
-[![Build Status](https://travis-ci.org/sarahquigley/coffeescript-lib-skeleton.svg?branch=add-travis-ci)](https://travis-ci.org/sarahquigley/coffeescript-lib-skeleton)
+[![Build Status](https://travis-ci.org/sarahquigley/coffeescript-lib-skeleton.svg)](https://travis-ci.org/sarahquigley/coffeescript-lib-skeleton)
 [![Dependency Status](https://gemnasium.com/sarahquigley/coffeescript-lib-skeleton.svg)](https://gemnasium.com/sarahquigley/coffeescript-lib-skeleton)
 [![devDependency Status](https://david-dm.org/sarahquigley/coffeescript-lib-skeleton/dev-status.svg)](https://david-dm.org/sarahquigley/coffeescript-lib-skeleton#info=devDependencies)
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,32 +17,36 @@ module.exports = function(config){
 
     frameworks: [
       'jasmine',
-      'jasmine-matchers'
+      'jasmine-matchers',
     ],
 
     // List of browsers to launch and capture
-    browsers : ['Chrome'],
+    browsers : [
+      'Chrome',
+      'PhantomJS',
+    ],
 
     plugins : [
       'karma-chrome-launcher',
       'karma-firefox-launcher',
+      'karma-phantomjs-launcher',
       'karma-jasmine',
       'karma-jasmine-matchers',
       'karma-jasmine-html-reporter',
       'karma-mocha-reporter',
       'karma-coffee-preprocessor',
-      'karma-ng-html2js-preprocessor'
+      'karma-ng-html2js-preprocessor',
     ],
 
     // List of reporters to use
     reporters: [
       'html',
-      'mocha'
+      'mocha',
     ],
 
     // Preprocessors to use
     preprocessors: {
-      'src/**/*.spec.coffee': 'coffee'
+      'src/**/*.spec.coffee': 'coffee',
     },
 
     // Coffeescript preprocessor config
@@ -50,7 +54,7 @@ module.exports = function(config){
       // options passed to the coffee compiler
       options: {
         bare: true,
-        sourceMap: false
+        sourceMap: false,
       },
       // transforming the filenames
       transformPath: function(path) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "karma-jasmine-matchers": "0.1.3",
     "karma-mocha-reporter": "~1.0.0",
     "karma-ng-html2js-preprocessor": "^0.1.2",
+    "karma-phantomjs-launcher": "^0.2.1",
     "load-grunt-tasks": "~3.1.0",
+    "phantomjs": "^1.9.18",
     "time-grunt": "~1.1.0"
   },
   "scripts": {


### PR DESCRIPTION
- Add very simple continuous integration with travis.
- Add david-dm and gemnasium badges for tracking node dev dependencies, and bower runtime dependencies.